### PR TITLE
logging: Enable logging output to also go to console

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,6 @@
+---
+docker:
+  builds:
+    - path: .
+      dockerfile: Dockerfile
+      docker_repo: resin/open-balena-registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/resin-base:v4.3.0
+FROM resin/resin-base:v4.4.0
 
 EXPOSE 80
 

--- a/config/services/resin-registry.service
+++ b/config/services/resin-registry.service
@@ -4,6 +4,8 @@ Requires=confd.service
 After=confd.service
 
 [Service]
+StandardOutput=journal+console
+StandardError=journal+console
 WorkingDirectory=/usr/src/app
 EnvironmentFile=/usr/src/app/config/env
 ExecStart=/usr/src/app/entry.sh


### PR DESCRIPTION
This change allows output to be captured by the Supervisor
on resinOS devices when run as a service.

Connects-to: #48
Change-type: minor
Signed-off-by: Heds Simons <heds@resin.io>
---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [x] Affects the development, build or deployment processes of the component
---- Autogenerated Waffleboard Connection: Connects to #48