### PR TITLE
dns: Ensure DNS is prioritised over MDNS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/resin-base:v4.4.0
+FROM resin/resin-base:v4.4.1
 
 EXPOSE 80
 


### PR DESCRIPTION
Updates `resin-base` to ensure DNS is prioritised
over MDNS, ensuring `.local` aliases are resolved
before those published on the local subnet.

Connects-to: #50
Change-type: patch
Signed-off-by: Heds Simons <heds@resin.io>
---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [x] Affects the development, build or deployment processes of the component
