### PR TITLE
service: Fix confd template for using S3 storage

### DIFF
--- a/config/confd_env_backend/templates/docker-registry.yml.tmpl
+++ b/config/confd_env_backend/templates/docker-registry.yml.tmpl
@@ -18,12 +18,12 @@ storage:
   cache:
     blobdescriptor: redis
 {{end}}
-{{if exists "REGISTRY2_S3_BUCKET"}}
+{{if getenv "REGISTRY2_S3_BUCKET"}}
   s3:
     accesskey: {{getenv "REGISTRY2_S3_KEY"}}
     secretkey: {{getenv "REGISTRY2_S3_SECRET"}}
     region: {{getenv "COMMON_REGION"}}
-{{if exists "REGISTRY2_S3_REGION_ENDPOINT"}}
+{{if getenv "REGISTRY2_S3_REGION_ENDPOINT"}}
     regionendpoint: {{getenv "REGISTRY2_S3_REGION_ENDPOINT"}}
 {{end}}
     bucket: {{getenv "REGISTRY2_S3_BUCKET"}}
@@ -36,7 +36,7 @@ storage:
     rootdirectory: {{getenv "REGISTRY2_STORAGEPATH"}}
 {{end}}
 
-{{if exists "REGISTRY2_S3_CLOUDFRONT_ENDPOINT"}}
+{{if getenv "REGISTRY2_S3_CLOUDFRONT_ENDPOINT"}}
 middleware:
   storage:
     - name: cloudfront

--- a/config/services/balena-registry.service
+++ b/config/services/balena-registry.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=balena-registry
-Requires=confd.service
-After=confd.service
+Requires=confd.service balena-root-ca.service
+After=confd.service balena-root-ca.service
 StartLimitIntervalSec=0
 
 [Service]


### PR DESCRIPTION
- the `exists` condition doesn't work for an ENV backend, so just check it has a value
- the registry service MUST start after the base' balena-root-ca service has completed, otherwise it may not trust the certificate used by the S3 endpoint.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>