### PR TITLE
Disable Redis database persistence

### DIFF
--- a/config/confd/templates/redis.conf.tmpl
+++ b/config/confd/templates/redis.conf.tmpl
@@ -215,9 +215,10 @@ always-show-logo yes
 #
 #   save ""
 
-save 900 1
-save 300 10
-save 60 10000
+# Disable database persistence
+#save 900 1
+#save 300 10
+#save 60 10000
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.

--- a/config/confd_env_backend/templates/redis.conf.tmpl
+++ b/config/confd_env_backend/templates/redis.conf.tmpl
@@ -199,9 +199,10 @@ databases 16
 #
 #   save ""
 
-save 900 1
-save 300 10
-save 60 10000
+# Disable database persistence
+#save 900 1
+#save 300 10
+#save 60 10000
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.


### PR DESCRIPTION
Redis persists the database *by default* which isn’t really something we want or need — we’re using it as a cache.

Change-type: minor