### PR TITLE
Increase the default max idle redis connections to 256

### DIFF
--- a/config/confd/templates/docker-registry.yml.tmpl
+++ b/config/confd/templates/docker-registry.yml.tmpl
@@ -74,7 +74,7 @@ redis:
   addr: {{getenv "REGISTRY2_CACHE_ADDR" "127.0.0.1:6379"}}
   db: {{getenv "REGISTRY2_CACHE_DB" "0"}}
   pool:
-    maxidle: {{getenv "REGISTRY2_CACHE_MAX_IDLE" "32"}}
+    maxidle: {{getenv "REGISTRY2_CACHE_MAX_IDLE" "256"}}
     maxactive: {{getenv "REGISTRY2_CACHE_MAX_ACTIVE" "1024"}}
     idletimeout: {{getenv "REGISTRY2_CACHE_IDLE_TIMEOUT" "300s"}}
 {{end}}


### PR DESCRIPTION
This brings it more in line with the default of 1024 max active
connections so that connections aren't killed as quickly during
spiky conditions

Change-type: patch