### PR TITLE
Conditionally enable S3 dualstack endpoints

### DIFF
--- a/config/confd/templates/docker-registry.yml.tmpl
+++ b/config/confd/templates/docker-registry.yml.tmpl
@@ -55,6 +55,10 @@ storage:
 {{if getenv "REGISTRY2_S3_REGION_ENDPOINT"}}
     regionendpoint: {{getenv "REGISTRY2_S3_REGION_ENDPOINT"}}
 {{end}}
+{{if getenv "REGISTRY2_S3_DUALSTACK"}}
+{{if eq (getenv "REGISTRY2_S3_DUALSTACK" "false") "true"}}
+    usedualstack: true
+{{end}}
     bucket: {{getenv "REGISTRY2_S3_BUCKET"}}
     encrypt: false
     secure: true


### PR DESCRIPTION
```
  s3:
    accesskey: awsaccesskey
    secretkey: awssecretkey
    region: us-west-1
    ...
    usedualstack: false
```

See, https://docs.docker.com/registry/configuration/#list-of-configuration-options