### PR TITLE
use latest build asset(s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,19 @@
+FROM alpine:latest AS build
+
+RUN apk add --no-cache github-cli
+
+ARG TARGETOS
+ARG TARGETARCH
+
+# https://github.com/distribution/distribution/actions/runs/5794478637
+ARG GH_RUN_ID=5794478637
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    && GH_TOKEN=$(cat < /run/secrets/GITHUB_TOKEN) gh run download -R distribution/distribution "${GH_RUN_ID}" -n registry \
+    && find . -type f -name "*_${TARGETOS}_${TARGETARCH}.tar.gz" | xargs tar -zxvf \
+    && ./registry --version
+
+
 FROM balena/open-balena-base:v15.0.3
 
 EXPOSE 80
@@ -10,19 +26,9 @@ RUN apt-get update \
 		redis-server \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV REGISTRY_VERSION 2.8.2
-ENV REGISTRY_SHA256_amd64 b68ffb849bcdb49639dc91ba97baba6618346f95fedc0fcc94871b31d515d205
-ENV REGISTRY_SHA256_arm64 3d500cf4f7f21ade4bdfef28012aef8e1ec2b221d2d8d36d201d94dda84fa727
-
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN asset="registry_${REGISTRY_VERSION}_linux_$(dpkg --print-architecture).tar.gz" && \
-	sha256="REGISTRY_SHA256_$(dpkg --print-architecture)" && \
-	curl -fsSL -O "https://github.com/distribution/distribution/releases/download/v${REGISTRY_VERSION}/${asset}" && \
-	echo "${!sha256} ${asset}" | sha256sum -c - && \
-	tar xz -f "${asset}" && \
-	mv registry /usr/local/bin/docker-registry && \
-	rm "${asset}"
+COPY --from=build /registry /usr/local/bin/docker-registry
 
 COPY config/services/ /etc/systemd/system/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG TARGETARCH
 ARG GH_RUN_ID=5794478637
 
 RUN --mount=type=secret,id=GITHUB_TOKEN \
-    && GH_TOKEN=$(cat < /run/secrets/GITHUB_TOKEN) gh run download -R distribution/distribution "${GH_RUN_ID}" -n registry \
+    GH_TOKEN=$(cat < /run/secrets/GITHUB_TOKEN) gh run download -R distribution/distribution "${GH_RUN_ID}" -n registry \
     && find . -type f -name "*_${TARGETOS}_${TARGETARCH}.tar.gz" | xargs tar -zxvf \
     && ./registry --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apk add --no-cache github-cli
 ARG TARGETOS
 ARG TARGETARCH
 
-# https://github.com/distribution/distribution/actions/runs/5794478637
+# https://github.com/distribution/distribution/actions/workflows/build.yml?query=branch%3Amain
+# (e.g.) https://github.com/distribution/distribution/actions/runs/5794478637
 ARG GH_RUN_ID=5794478637
 
 RUN --mount=type=secret,id=GITHUB_TOKEN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest AS build
+FROM alpine:3.18.3 AS build
 
 RUN apk add --no-cache github-cli
 


### PR DESCRIPTION
Since Docker are having issues releasing their software, this is a workaround to use a more recent CI release/build.

Passed in staging using IPv6-only AWS instance.