### PR TITLE
fix: make docker-registry compatible with Cloudflare R2 storage

### DIFF
--- a/config/confd/templates/docker-registry.yml.tmpl
+++ b/config/confd/templates/docker-registry.yml.tmpl
@@ -63,6 +63,7 @@ storage:
     secure: true
     v4auth: true
     rootdirectory: {{getenv "REGISTRY2_STORAGEPATH"}}
+    chunksize: 104857600
 {{else}}
   filesystem:
     rootdirectory: {{getenv "REGISTRY2_STORAGEPATH"}}


### PR DESCRIPTION
See https://community.cloudflare.com/t/all-non-trailing-parts-must-have-the-same-length/552190/6 for more context