### PR TITLE
Use jwks for token auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /package-lock.json
+jwks/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN asset="registry_${REGISTRY_VERSION}_linux_$(dpkg --print-architecture).tar.g
 
 COPY . /usr/src/app
 
+WORKDIR /usr/src/app/jwks
+RUN JOBS=max npm i
+WORKDIR /
+
 # The ENTRYPOINT inherited from open-balena-base:no-systemd is "/usr/bin/confd-entry.sh"
 # so we need to pass our own entrypoint as the CMD
 CMD [ "/usr/src/app/entry.sh" ]

--- a/config/confd/templates/docker-registry.yml.tmpl
+++ b/config/confd/templates/docker-registry.yml.tmpl
@@ -27,6 +27,7 @@ auth:
     realm: {{getenv "REGISTRY2_TOKEN_AUTH_REALM"}}
     issuer: {{getenv "REGISTRY2_TOKEN_AUTH_ISSUER"}}
     rootcertbundle: /tmp/registry-tokenauth.crt
+    jwks: /etc/jwks
 {{end}}
 
 storage:

--- a/entry.sh
+++ b/entry.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 echo "${TOKEN_AUTH_ROOTCERTBUNDLE}" | base64 --decode >"${CERT_FILE}"
+node /usr/src/app/jwks/index.js
 
 exec /usr/local/bin/docker-registry serve /etc/docker-registry.yml

--- a/jwks/.npmrc
+++ b/jwks/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/jwks/index.js
+++ b/jwks/index.js
@@ -1,0 +1,26 @@
+const jose = require('node-jose');
+const fs = require('node:fs');
+
+async function main() {
+	const issuer = process.env['TOKEN_AUTH_CERT_ISSUER'];
+	if (!issuer) {
+		throw new Error('TOKEN_AUTH_CERT_ISSUER not set, giving up on JWKS generation');
+	}
+	const pem = fs.readFileSync(`/certs/private/${issuer}.pem`, 'utf8');
+	const kid = fs.readFileSync(`/certs/private/${issuer}.kid`, 'utf8').trim();
+	const keystore = jose.JWK.createKeyStore();
+	await keystore.add(pem, 'pem', { use: 'sig', alg: 'ES256' });
+	const jwks = keystore.toJSON(true);
+	if (jwks.keys != null && jwks.keys[0] != null) {
+		jwks.keys[0].kid = kid;
+	}
+	fs.writeFileSync('/etc/jwks', JSON.stringify(jwks, null, 2));
+}
+
+main().then(() => {
+	console.log('PWKS written to /etc/pwks');
+	process.exit(0);
+}).catch((err) => {
+	console.error('Error writing PWKS:', err);
+	process.exit(1);
+});

--- a/jwks/package.json
+++ b/jwks/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "jwks",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "node-jose": "^2.2.0"
+  }
+}


### PR DESCRIPTION
Change-type: patch

---

Generate and use a `jwks` file for token auth. This should allow tokens generated by our API to work with registry v3.
We would probably want to generate this file ahead of time and serve it alongside other certificate data instead of generating on registry init. This is currently meant to be a proof of concept and starting point.

See: https://balena.fibery.io/favorites/Work/Project/1508