### PR TITLE
Use JWKS for token auth

### DIFF
--- a/config/confd/templates/docker-registry.yml.tmpl
+++ b/config/confd/templates/docker-registry.yml.tmpl
@@ -27,6 +27,7 @@ auth:
     realm: {{getenv "REGISTRY2_TOKEN_AUTH_REALM"}}
     issuer: {{getenv "REGISTRY2_TOKEN_AUTH_ISSUER"}}
     rootcertbundle: /tmp/registry-tokenauth.crt
+    jwks: /tmp/registry-jwks.json
 {{end}}
 
 storage:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,6 +6,7 @@ services:
     image: sut
     environment:
       REGISTRY2_PROXY_ENABLED: true
+      API_TOKENAUTH_JWKS: ewogICJrZXlzIjogWwogICAgewogICAgICAia3R5IjogIkVDIiwKICAgICAgIngiOiAieC1kdW1teS12YWx1ZSIsCiAgICAgICJ5IjogInktZHVtbXktdmFsdWUiLAogICAgICAiY3J2IjogIlAtMjU2IiwKICAgICAgInVzZSI6ICJzaWciLAogICAgICAiYWxnIjogIkVTMjU2IiwKICAgICAgImtpZCI6ICJraWQtZHVtbXktdmFsdWUiLAogICAgICAieDV0IjogIng1dC1kdW1teS12YWx1ZSIKICAgIH0KICBdCn0=
     tmpfs:
       - /data:exec
 

--- a/entry.sh
+++ b/entry.sh
@@ -2,4 +2,19 @@
 
 echo "${TOKEN_AUTH_ROOTCERTBUNDLE}" | base64 --decode >"${CERT_FILE}"
 
+# Prepare the registry JWKS file
+jwks_cert_file="/certs/private/${TOKEN_AUTH_CERT_ISSUER}.jwks.json"
+registry_jwks_file="/tmp/registry-jwks.json"
+if [ -f "${jwks_cert_file}" ]; then
+    ln -s "${jwks_cert_file}" "${registry_jwks_file}"
+elif [ -n "${API_TOKENAUTH_JWKS}" ]; then
+    echo "${API_TOKENAUTH_JWKS}" | base64 --decode >"${registry_jwks_file}"
+fi
+
+# Ensure the registry JWKS file exists and is valid JSON
+if ! jq -e . "${registry_jwks_file}" > /dev/null 2>&1; then
+    echo "Error: Registry JWKS file not found or is invalid." >&2
+    exit 1
+fi
+
 exec /usr/local/bin/docker-registry serve /etc/docker-registry.yml


### PR DESCRIPTION
Change-type: patch

---

See: https://balena.fibery.io/Work/Project/Mark-associated-resources-for-deletion-when-a-release-is-deleted-1779

Depends on:
- https://github.com/balena-io/cert-manager/pull/54